### PR TITLE
Add configurable serialStartupDelay.

### DIFF
--- a/sfeDataLoggerIoT/sfeDataLogger.cpp
+++ b/sfeDataLoggerIoT/sfeDataLogger.cpp
@@ -868,8 +868,13 @@ void sfeDataLogger::onInit(void)
     theRate = theRate >= 1200 ? theRate : kDefaultTerminalBaudRate;
 
     Serial.begin(theRate);
-    while (!Serial)
-        ;
+
+    uint32_t baseMillis = millis();
+    while (!Serial) {
+        if ((millis() - baseMillis) > startupSerialDelay)
+            break;
+        delay(250);
+    }
 
     sfeLED.initialize();
     sfeLED.on(sfeLED.Green);

--- a/sfeDataLoggerIoT/sfeDataLogger.h
+++ b/sfeDataLoggerIoT/sfeDataLogger.h
@@ -387,6 +387,8 @@ class sfeDataLogger : public flxApplication
     bool  _bSleepEnabled;
     sfeDLLoopEvent  _sleepEvent = {"SLEEP", kSystemSleepWakeSec*1000, 0};
 
+    uint32_t startupSerialDelay = 5000;
+
 #ifdef ENABLE_OLED_DISPLAY
     sfeDLDisplay  *_pDisplay;
 #endif


### PR DESCRIPTION
Adds delay to prevent device from failing to boot if there's no serial.

Fixes #14 